### PR TITLE
Dashboard css

### DIFF
--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -19,9 +19,9 @@ class DashboardView extends Component {
           <NewPresButton/>
           <Link to={'/summary/cc0001'}>Summary</Link>
           <Searchbar/>
+          <JoinPresBox />
         </div>
         <DashMainContent/>
-        <JoinPresBox />
       </div>
     );
   };

--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -13,13 +13,13 @@ class DashboardView extends Component {
 
   render () {
     return (
-      <div className='container'>
+      <div>
         <Navbar/>
-        <div className='row'>
-          <NewPresButton className='col' />
-          <Link to={'/summary/cc0001'} className='row'>Summary</Link>
-          <Searchbar className='row'/>
-          <JoinPresBox className='row'/>
+        <div>
+          <NewPresButton/>
+          <Link to={'/summary/cc0001'}>Summary</Link>
+          <Searchbar/>
+          <JoinPresBox/>
         </div>
         <DashMainContent/>
       </div>

--- a/client/src/components/DashboardView.jsx
+++ b/client/src/components/DashboardView.jsx
@@ -13,13 +13,13 @@ class DashboardView extends Component {
 
   render () {
     return (
-      <div>
+      <div className='container'>
         <Navbar/>
-        <div>
-          <NewPresButton/>
-          <Link to={'/summary/cc0001'}>Summary</Link>
-          <Searchbar/>
-          <JoinPresBox />
+        <div className='row'>
+          <NewPresButton className='col' />
+          <Link to={'/summary/cc0001'} className='row'>Summary</Link>
+          <Searchbar className='row'/>
+          <JoinPresBox className='row'/>
         </div>
         <DashMainContent/>
       </div>


### PR DESCRIPTION
Moved JoinPresBox to same div as NewPres.
JoinPresBox renders at same height as NewPres and Summary, but at right side of page. 
Will work on moving JoinPresBox to left, but wanted to have these changes available to everyone else.